### PR TITLE
feat: update spa-frontend module security settings

### DIFF
--- a/modules/ssg-frontend/variables.tf
+++ b/modules/ssg-frontend/variables.tf
@@ -12,6 +12,7 @@ variable "domain_names" {
 variable "acm_certificate_arn" {
   description = "ACM証明書のARN"
   type        = string
+  default     = null
 }
 
 variable "price_class" {


### PR DESCRIPTION
SSGモジュールの変更に合わせて、SPAモジュールのセキュリティ設定を更新しました。

## 変更内容
- KMSキーのポリシーにCloudFront OACのアクセス許可を追加
- aws_caller_identityデータソースを追加

## 確認項目
- [ ] KMSキーのポリシーが正しく設定されているか
- [ ] CloudFrontのOACアクセスが正しく動作するか